### PR TITLE
Add Reduced Diagnostics: BeamRelevant

### DIFF
--- a/Docs/source/running_cpp/parameters.rst
+++ b/Docs/source/running_cpp/parameters.rst
@@ -225,7 +225,7 @@ Particle initialization
 
 * ``<species_name>.do_continuous_injection`` (`0` or `1`)
     Whether to inject particles during the simulation, and not only at
-    initialization. This can be required whith a moving window and/or when
+    initialization. This can be required with a moving window and/or when
     running in a boosted frame.
 
 * ``<species_name>.initialize_self_fields`` (`0` or `1`)
@@ -296,7 +296,7 @@ Particle initialization
 
       Note that though the particles may move at relativistic speeds in the simulation frame,
       they are not relativistic in the drift frame. This is as opposed to the Maxwell Juttner
-      setting, which initializes particles with relativistc momentums in their drifting frame.
+      setting, which initializes particles with relativistic momentums in their drifting frame.
 
     * ``maxwell_juttner``: Maxwell-Juttner distribution for high temperature plasma. This mode
       requires a dimensionless temperature parameter ``<species_name>.theta``, where theta is equal
@@ -708,7 +708,7 @@ Laser initialization
     required additional parameters in the input file, namely,
     ``warpx.Ex_external_grid_function(x,y,z)``,
     ``warpx.Ey_external_grid_function(x,y,z)``,
-    ``warpx.Ez_externail_grid_function(x,y,z)`` to initialize the external
+    ``warpx.Ez_external_grid_function(x,y,z)`` to initialize the external
     electric field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
     For example, if ``warpx.Ex_external_grid_function(x,y,z)=Eo*x + delta*(y + z)``
@@ -753,7 +753,7 @@ Laser initialization
      This parameter determines the type of initialization for the external
      electric field that is applied directly to the particles at every timestep.
      The "default" style set the external E-field (Ex,Ey,Ez) to (0.0,0.0,0.0).
-     The string can be set to "constant" if a cosntant external E-field is to be
+     The string can be set to "constant" if a constant external E-field is to be
      used in the simulation at every timestep. If this parameter is set to "constant",
      then an additional parameter, namely, ``particles.E_external_particle`` must be
      specified in the input file.
@@ -1104,7 +1104,7 @@ Diagnostics and output
 * ``<reduced_diags_name>.type`` (`string`)
     The type of reduced diagnostics associated with this `<reduced_diags_name>`.
     For example, ``ParticleEnergy`` and ``FieldEnergy``.
-    All available types will be descriped below in detail.
+    All available types will be described below in detail.
     For all reduced diagnostics,
     the first and the second columns in the output file are
     the time step and the corresponding physical time in seconds, respectively.
@@ -1127,7 +1127,7 @@ Diagnostics and output
         total :math:`E_p` of all species,
         :math:`E_p` of each species,
         total mean energy :math:`E_p / \sum w_i`,
-        mean enregy of each species.
+        mean energy of each species.
 
     * ``FieldEnergy``
         This type computes the electric and magnetic field energy.
@@ -1148,6 +1148,45 @@ Diagnostics and output
         total field energy :math:`E_f`,
         :math:`E` field energy,
         :math:`B` field energy, at mesh refinement levels from 0 to :math:`n`.
+
+    * ``BeamRelevant``
+        This type computes some quantities that are relevant to a beam.
+
+        `<reduced_diags_name>.species` must be provided,
+        such that the diagnostics are done for this (beam-like) species only.
+
+        The output columns are the following:
+
+        [1], [2], [3]: The mean values of beam positions
+        :math:`\langle x \rangle`, :math:`\langle y \rangle`,
+        :math:`\langle z \rangle`.
+
+        [4], [5], [6]: The mean values of beam relativistic velocities
+        :math:`\langle u_x \rangle`, :math:`\langle u_y \rangle`,
+        :math:`\langle u_z \rangle`.
+
+        [7]: The mean Lorentz factor :math:`\langle \gamma \rangle`.
+
+        [8], [9], [10]: The RMS values of beam positions
+        :math:`\delta_x = \sqrt{ \langle (x - \langle x \rangle)^2 \rangle }`,
+        :math:`\delta_y = \sqrt{ \langle (y - \langle y \rangle)^2 \rangle }`,
+        :math:`\delta_z = \sqrt{ \langle (z - \langle z \rangle)^2 \rangle }`.
+
+        [11], [12], [13]: The RMS values of beam relativistic velocities
+        :math:`\delta_{ux} = \sqrt{ \langle (u_x - \langle u_x \rangle)^2 \rangle }`,
+        :math:`\delta_{uy} = \sqrt{ \langle (u_y - \langle u_y \rangle)^2 \rangle }`,
+        :math:`\delta_{uz} = \sqrt{ \langle (u_z - \langle u_z \rangle)^2 \rangle }`.
+
+        [14]: The RMS value of the Lorentz factor
+        :math:`\sqrt{ \langle (\gamma - \langle \gamma \rangle)^2 \rangle }`.
+
+        [15], [16], [17]: beam emittance
+        :math:`\epsilon_x = \dfrac{1}{c} \sqrt{\delta_x^2 \delta_{ux}^2 -
+        \Big\langle (x-\langle x \rangle) (u_x-\langle u_x \rangle) \Big\rangle^2}`,
+        :math:`\epsilon_y = \dfrac{1}{c} \sqrt{\delta_y^2 \delta_{uy}^2 -
+        \Big\langle (y-\langle y \rangle) (u_y-\langle u_y \rangle) \Big\rangle^2}`,
+        :math:`\epsilon_z = \dfrac{1}{c} \sqrt{\delta_z^2 \delta_{uz}^2 -
+        \Big\langle (z-\langle z \rangle) (u_z-\langle u_z \rangle) \Big\rangle^2}`.
 
 * ``<reduced_diags_name>.frequency`` (`int`)
     The output frequency (every # time steps).

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.H
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.H
@@ -1,0 +1,29 @@
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_BEAMRELEVANT_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_BEAMRELEVANT_H_
+
+#include "ReducedDiags.H"
+#include <fstream>
+
+/**
+ *  This class contains diagnostics that are relevant to beam.
+*/
+class BeamRelevant : public ReducedDiags
+{
+public:
+
+    /** constructor
+     *  @param[in] rd_name reduced diags names */
+    BeamRelevant(std::string rd_name);
+
+    /// name of beam species
+    std::string m_beam_name;
+
+    /** This funciton computes beam relevant quantites.
+     *  \param [in] step current time step
+     *  */
+    virtual void ComputeDiags(int step) override final;
+
+};
+///< end class BeamRelevant
+
+#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_BEAMRELEVANT_H_

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -38,25 +38,25 @@ BeamRelevant::BeamRelevant (std::string rd_name)
                 std::ofstream::out | std::ofstream::app);
             /// write header row
             ofs << "#";
-            ofs << "step";            ofs << m_sep;
-            ofs << "time(s)";         ofs << m_sep;
-            ofs << "x_mean(m)";       ofs << m_sep;
-            ofs << "y_mean(m)";       ofs << m_sep;
-            ofs << "z_mean(m)";       ofs << m_sep;
-            ofs << "ux_mean(m/s)";    ofs << m_sep;
-            ofs << "uy_mean(m/s)";    ofs << m_sep;
-            ofs << "uz_mean(m/s)";    ofs << m_sep;
-            ofs << "gamma_mean";      ofs << m_sep;
-            ofs << "x_rms(m)";        ofs << m_sep;
-            ofs << "y_rms(m)";        ofs << m_sep;
-            ofs << "z_rms(m)";        ofs << m_sep;
-            ofs << "ux_rms(m/s)";     ofs << m_sep;
-            ofs << "uy_rms(m/s)";     ofs << m_sep;
-            ofs << "uz_rms(m/s)";     ofs << m_sep;
-            ofs << "gamma_rms";       ofs << m_sep;
-            ofs << "emittance_x(m)";  ofs << m_sep;
-            ofs << "emittance_y(m)";  ofs << m_sep;
-            ofs << "emittance_z(m)";  ofs << std::endl;
+            ofs << "(1)step";             ofs << m_sep;
+            ofs << "(2)time(s)";          ofs << m_sep;
+            ofs << "(3)x_mean(m)";        ofs << m_sep;
+            ofs << "(4)y_mean(m)";        ofs << m_sep;
+            ofs << "(5)z_mean(m)";        ofs << m_sep;
+            ofs << "(6)ux_mean(m/s)";     ofs << m_sep;
+            ofs << "(7)uy_mean(m/s)";     ofs << m_sep;
+            ofs << "(8)uz_mean(m/s)";     ofs << m_sep;
+            ofs << "(9)gamma_mean";       ofs << m_sep;
+            ofs << "(10)x_rms(m)";        ofs << m_sep;
+            ofs << "(11)y_rms(m)";        ofs << m_sep;
+            ofs << "(12)z_rms(m)";        ofs << m_sep;
+            ofs << "(13)ux_rms(m/s)";     ofs << m_sep;
+            ofs << "(14)uy_rms(m/s)";     ofs << m_sep;
+            ofs << "(15)uz_rms(m/s)";     ofs << m_sep;
+            ofs << "(16)gamma_rms";       ofs << m_sep;
+            ofs << "(17)emittance_x(m)";  ofs << m_sep;
+            ofs << "(18)emittance_y(m)";  ofs << m_sep;
+            ofs << "(19)emittance_z(m)";  ofs << std::endl;
             /// close file
             ofs.close();
         }

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -1,0 +1,286 @@
+#include "BeamRelevant.H"
+#include "WarpX.H"
+#include "WarpXConst.H"
+#include "AMReX_REAL.H"
+#include "AMReX_ParticleReduce.H"
+#include <iostream>
+#include <cmath>
+#include <limits>
+
+using namespace amrex;
+
+/// constructor
+BeamRelevant::BeamRelevant (std::string rd_name)
+: ReducedDiags{rd_name}
+{
+
+    /// read beam name
+    ParmParse pp(rd_name);
+    pp.get("beam_name",m_beam_name);
+
+    /// resize data array
+    ///  0 --  2: mean x,y,z
+    ///  3 --  5: mean ux,uy,uz
+    ///        6: gamma
+    ///  7 --  9: rms x,y,z
+    /// 10 -- 12: rms ux,uy,uz
+    ///       13: rms gamma
+    /// 14 -- 16: emittance x,y,z
+    m_data.resize(17,0.0);
+
+    if (ParallelDescriptor::IOProcessor())
+    {
+        if ( m_IsNotRestart )
+        {
+            /// open file
+            std::ofstream ofs;
+            ofs.open(m_path + m_rd_name + ".txt",
+                std::ofstream::out | std::ofstream::app);
+            /// write header row
+            ofs << "#";
+            ofs << "step";            ofs << m_sep;
+            ofs << "time(s)";         ofs << m_sep;
+            ofs << "x_mean(m)";       ofs << m_sep;
+            ofs << "y_mean(m)";       ofs << m_sep;
+            ofs << "z_mean(m)";       ofs << m_sep;
+            ofs << "ux_mean(m/s)";    ofs << m_sep;
+            ofs << "uy_mean(m/s)";    ofs << m_sep;
+            ofs << "uz_mean(m/s)";    ofs << m_sep;
+            ofs << "gamma_mean";      ofs << m_sep;
+            ofs << "x_rms(m)";        ofs << m_sep;
+            ofs << "y_rms(m)";        ofs << m_sep;
+            ofs << "z_rms(m)";        ofs << m_sep;
+            ofs << "ux_rms(m/s)";     ofs << m_sep;
+            ofs << "uy_rms(m/s)";     ofs << m_sep;
+            ofs << "uz_rms(m/s)";     ofs << m_sep;
+            ofs << "gamma_rms";       ofs << m_sep;
+            ofs << "emittance_x(m)";  ofs << m_sep;
+            ofs << "emittance_y(m)";  ofs << m_sep;
+            ofs << "emittance_z(m)";  ofs << std::endl;
+            /// close file
+            ofs.close();
+        }
+    }
+
+}
+///< end constructor
+
+/// function that compute
+void BeamRelevant::ComputeDiags (int step)
+{
+
+    /// Judge if the diags should be done
+    if ( (step+1) % m_freq != 0 ) { return; }
+
+    /// get MultiParticleContainer class object
+    auto & mypc = WarpX::GetInstance().GetPartContainer();
+
+    /// get number of species (int)
+    auto nSpecies = mypc.nSpecies();
+
+    /// get species names (std::vector<std::string>)
+    auto species_names = mypc.GetSpeciesNames();
+
+    /// inverse of speed of light squared
+    auto inv_c2 = 1.0 / (PhysConst::c * PhysConst::c);
+
+    /// loop over species
+    for (int i_s = 0; i_s < nSpecies; ++i_s)
+    {
+
+        /// only beam species
+        if (species_names[i_s] != m_beam_name) { continue; }
+
+        /// get WarpXParticleContainer class object
+        auto & myspc = mypc.GetParticleContainer(i_s);
+
+        /// get mass (Real)
+        auto m = myspc.getMass();
+
+        using PType = typename WarpXParticleContainer::SuperParticleType;
+
+        /// weight sum
+        auto w_sum = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.rdata(PIdx::w); });
+
+        /// reduced sum over mpi ranks
+        ParallelDescriptor::ReduceRealSum(w_sum);
+
+        if (w_sum < std::numeric_limits<Real>::min() )
+        {
+            for (int i = 0; i < m_data.size(); ++i) { m_data[i] = 0.0; }
+            return;
+        }
+
+        /// x mean
+        auto x_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.pos(0) * p.rdata(PIdx::w) / w_sum; });
+
+        /// y mean
+        auto y_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.pos(1) * p.rdata(PIdx::w) / w_sum; });
+
+        /// z mean
+        auto z_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.pos(2) * p.rdata(PIdx::w) / w_sum; });
+
+        /// ux mean
+        auto ux_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.rdata(PIdx::ux) * p.rdata(PIdx::w) / w_sum; });
+
+        /// uy mean
+        auto uy_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.rdata(PIdx::uy) * p.rdata(PIdx::w) / w_sum; });
+
+        /// uz mean
+        auto uz_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        { return p.rdata(PIdx::uz) * p.rdata(PIdx::w) / w_sum; });
+
+        /// gamma mean
+        auto gm_mean = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto ux = p.rdata(PIdx::ux);
+            auto uy = p.rdata(PIdx::uy);
+            auto uz = p.rdata(PIdx::uz);
+            auto us = ux*ux + uy*uy + uz*uz;
+            return std::sqrt(1.0 + us*inv_c2) * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// reduced sum over mpi ranks
+        ParallelDescriptor::ReduceRealSum(x_mean);
+        ParallelDescriptor::ReduceRealSum(y_mean);
+        ParallelDescriptor::ReduceRealSum(z_mean);
+        ParallelDescriptor::ReduceRealSum(ux_mean);
+        ParallelDescriptor::ReduceRealSum(uy_mean);
+        ParallelDescriptor::ReduceRealSum(uz_mean);
+        ParallelDescriptor::ReduceRealSum(gm_mean);
+
+        /// x rms
+        auto x_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(0)-x_mean) * (p.pos(0)-x_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// y rms
+        auto y_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(1)-y_mean) * (p.pos(1)-y_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// z rms
+        auto z_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(2)-z_mean) * (p.pos(2)-z_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// ux rms
+        auto ux_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.rdata(PIdx::ux)-ux_mean) * (p.rdata(PIdx::ux)-ux_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// uy rms
+        auto uy_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.rdata(PIdx::uy)-uy_mean) * (p.rdata(PIdx::uy)-uy_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// uz rms
+        auto uz_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.rdata(PIdx::uz)-uz_mean) * (p.rdata(PIdx::uz)-uz_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// gamma rms
+        auto gm_rms = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto ux = p.rdata(PIdx::ux);
+            auto uy = p.rdata(PIdx::uy);
+            auto uz = p.rdata(PIdx::uz);
+            auto us = ux*ux + uy*uy + uz*uz;
+            auto gm = std::sqrt(1.0 + us*inv_c2);
+            auto a  = (gm - gm_mean) * (gm - gm_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// x times ux
+        auto xux = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(0)-x_mean) * (p.rdata(PIdx::ux)-ux_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// y times uy
+        auto yuy = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(1)-y_mean) * (p.rdata(PIdx::uy)-uy_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// z times uz
+        auto zuz = ReduceSum( myspc,
+        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+        {
+            auto a = (p.pos(2)-z_mean) * (p.rdata(PIdx::uz)-uz_mean);
+            return a * p.rdata(PIdx::w) / w_sum;
+        });
+
+        /// reduced sum over mpi ranks
+        ParallelDescriptor::ReduceRealSum(x_rms);
+        ParallelDescriptor::ReduceRealSum(y_rms);
+        ParallelDescriptor::ReduceRealSum(z_rms);
+        ParallelDescriptor::ReduceRealSum(ux_rms);
+        ParallelDescriptor::ReduceRealSum(uy_rms);
+        ParallelDescriptor::ReduceRealSum(uz_rms);
+        ParallelDescriptor::ReduceRealSum(gm_rms);
+        ParallelDescriptor::ReduceRealSum(xux);
+        ParallelDescriptor::ReduceRealSum(yuy);
+        ParallelDescriptor::ReduceRealSum(zuz);
+
+        /// save data
+        m_data[0]  = x_mean;
+        m_data[1]  = y_mean;
+        m_data[2]  = z_mean;
+        m_data[3]  = ux_mean;
+        m_data[4]  = uy_mean;
+        m_data[5]  = uz_mean;
+        m_data[6]  = gm_mean;
+        m_data[7]  = std::sqrt(x_rms);
+        m_data[8]  = std::sqrt(y_rms);
+        m_data[9]  = std::sqrt(z_rms);
+        m_data[10] = std::sqrt(ux_rms);
+        m_data[11] = std::sqrt(uy_rms);
+        m_data[12] = std::sqrt(uz_rms);
+        m_data[13] = std::sqrt(gm_rms);
+        m_data[14] = std::sqrt(std::abs(x_rms*ux_rms-xux*xux)) / PhysConst::c;
+        m_data[15] = std::sqrt(std::abs(y_rms*uy_rms-yuy*yuy)) / PhysConst::c;
+        m_data[16] = std::sqrt(std::abs(z_rms*uz_rms-zuz*zuz)) / PhysConst::c;
+
+    }
+    ///< end loop over species
+
+}
+///< end void BeamRelevant::ComputeDiags

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -19,13 +19,13 @@ BeamRelevant::BeamRelevant (std::string rd_name)
     pp.get("beam_name",m_beam_name);
 
     /// resize data array
-    ///  0 --  2: mean x,y,z
-    ///  3 --  5: mean ux,uy,uz
+    ///  0, 1, 2: mean x,y,z
+    ///  3, 4, 5: mean ux,uy,uz
     ///        6: gamma
-    ///  7 --  9: rms x,y,z
-    /// 10 -- 12: rms ux,uy,uz
+    ///  7, 8, 9: rms x,y,z
+    /// 10,11,12: rms ux,uy,uz
     ///       13: rms gamma
-    /// 14 -- 16: emittance x,y,z
+    /// 14,15,16: emittance x,y,z
     m_data.resize(17,0.0);
 
     if (ParallelDescriptor::IOProcessor())
@@ -34,29 +34,29 @@ BeamRelevant::BeamRelevant (std::string rd_name)
         {
             /// open file
             std::ofstream ofs;
-            ofs.open(m_path + m_rd_name + ".txt",
+            ofs.open(m_path + m_rd_name + "." + m_extension,
                 std::ofstream::out | std::ofstream::app);
             /// write header row
             ofs << "#";
-            ofs << "(1)step";             ofs << m_sep;
-            ofs << "(2)time(s)";          ofs << m_sep;
-            ofs << "(3)x_mean(m)";        ofs << m_sep;
-            ofs << "(4)y_mean(m)";        ofs << m_sep;
-            ofs << "(5)z_mean(m)";        ofs << m_sep;
-            ofs << "(6)ux_mean(m/s)";     ofs << m_sep;
-            ofs << "(7)uy_mean(m/s)";     ofs << m_sep;
-            ofs << "(8)uz_mean(m/s)";     ofs << m_sep;
-            ofs << "(9)gamma_mean";       ofs << m_sep;
-            ofs << "(10)x_rms(m)";        ofs << m_sep;
-            ofs << "(11)y_rms(m)";        ofs << m_sep;
-            ofs << "(12)z_rms(m)";        ofs << m_sep;
-            ofs << "(13)ux_rms(m/s)";     ofs << m_sep;
-            ofs << "(14)uy_rms(m/s)";     ofs << m_sep;
-            ofs << "(15)uz_rms(m/s)";     ofs << m_sep;
-            ofs << "(16)gamma_rms";       ofs << m_sep;
-            ofs << "(17)emittance_x(m)";  ofs << m_sep;
-            ofs << "(18)emittance_y(m)";  ofs << m_sep;
-            ofs << "(19)emittance_z(m)";  ofs << std::endl;
+            ofs << "[1]step";             ofs << m_sep;
+            ofs << "[2]time(s)";          ofs << m_sep;
+            ofs << "[3]x_mean(m)";        ofs << m_sep;
+            ofs << "[4]y_mean(m)";        ofs << m_sep;
+            ofs << "[5]z_mean(m)";        ofs << m_sep;
+            ofs << "[6]ux_mean(m/s)";     ofs << m_sep;
+            ofs << "[7]uy_mean(m/s)";     ofs << m_sep;
+            ofs << "[8]uz_mean(m/s)";     ofs << m_sep;
+            ofs << "[9]gamma_mean";       ofs << m_sep;
+            ofs << "[10]x_rms(m)";        ofs << m_sep;
+            ofs << "[11]y_rms(m)";        ofs << m_sep;
+            ofs << "[12]z_rms(m)";        ofs << m_sep;
+            ofs << "[13]ux_rms(m/s)";     ofs << m_sep;
+            ofs << "[14]uy_rms(m/s)";     ofs << m_sep;
+            ofs << "[15]uz_rms(m/s)";     ofs << m_sep;
+            ofs << "[16]gamma_rms";       ofs << m_sep;
+            ofs << "[17]emittance_x(m)";  ofs << m_sep;
+            ofs << "[18]emittance_y(m)";  ofs << m_sep;
+            ofs << "[19]emittance_z(m)";  ofs << std::endl;
             /// close file
             ofs.close();
         }
@@ -65,7 +65,7 @@ BeamRelevant::BeamRelevant (std::string rd_name)
 }
 ///< end constructor
 
-/// function that compute
+/// function that compute beam relevant quantities
 void BeamRelevant::ComputeDiags (int step)
 {
 
@@ -88,7 +88,7 @@ void BeamRelevant::ComputeDiags (int step)
     for (int i_s = 0; i_s < nSpecies; ++i_s)
     {
 
-        /// only beam species
+        /// only beam species does
         if (species_names[i_s] != m_beam_name) { continue; }
 
         /// get WarpXParticleContainer class object
@@ -249,16 +249,26 @@ void BeamRelevant::ComputeDiags (int step)
         });
 
         /// reduced sum over mpi ranks
-        ParallelDescriptor::ReduceRealSum(x_rms);
-        ParallelDescriptor::ReduceRealSum(y_rms);
-        ParallelDescriptor::ReduceRealSum(z_rms);
-        ParallelDescriptor::ReduceRealSum(ux_rms);
-        ParallelDescriptor::ReduceRealSum(uy_rms);
-        ParallelDescriptor::ReduceRealSum(uz_rms);
-        ParallelDescriptor::ReduceRealSum(gm_rms);
-        ParallelDescriptor::ReduceRealSum(xux);
-        ParallelDescriptor::ReduceRealSum(yuy);
-        ParallelDescriptor::ReduceRealSum(zuz);
+        ParallelDescriptor::ReduceRealSum
+            ( x_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            ( y_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            ( z_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (ux_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (uy_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (uz_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (gm_rms, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (   xux, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (   yuy, ParallelDescriptor::IOProcessorNumber());
+        ParallelDescriptor::ReduceRealSum
+            (   zuz, ParallelDescriptor::IOProcessorNumber());
 
         /// save data
         m_data[0]  = x_mean;

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -10,5 +10,8 @@ CEXE_sources += ParticleEnergy.cpp
 CEXE_headers += FieldEnergy.H
 CEXE_sources += FieldEnergy.cpp
 
+CEXE_headers += BeamRelevant.H
+CEXE_sources += BeamRelevant.cpp
+
 INCLUDE_LOCATIONS += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Diagnostics/ReducedDiags

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -1,3 +1,4 @@
+#include "BeamRelevant.H"
 #include "ParticleEnergy.H"
 #include "FieldEnergy.H"
 #include "MultiReducedDiags.H"
@@ -41,6 +42,11 @@ MultiReducedDiags::MultiReducedDiags ()
         {
             m_multi_rd[i_rd].reset
                 ( new FieldEnergy(m_rd_names[i_rd]));
+        }
+        else if (rd_type.compare("BeamRelevant") == 0)
+        {
+            m_multi_rd[i_rd].reset
+                ( new BeamRelevant(m_rd_names[i_rd]));
         }
         else
         { Abort("No matching reduced diagnostics type found."); }


### PR DESCRIPTION
This is a follow-up PR of `Add Reduced Diagnostics #580`.
In this PR, another reduced diagnostic, named as `BeamRelevant`, is added into the Reduced Diagnostics Class.
`BeamRelevant` is designed for outputting some characteristic diagnostics for a beam.
Output columns are:
```
    ///  0, 1, 2: mean x,y,z
    ///  3, 4, 5: mean ux,uy,uz
    ///        6: gamma
    ///  7, 8, 9: rms x,y,z
    /// 10,11,12: rms ux,uy,uz
    ///       13: rms gamma
    /// 14,15,16: emittance x,y,z
```